### PR TITLE
Upgrade to latest version of zenoss-py-deps

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ ITERATION ?= 1
 PLATFORM = x86_64
 RPMVERSION := $(subst -,_,$(VERSION))
 RPM =  $(NAME)-$(RPMVERSION)-$(ITERATION).$(PLATFORM).rpm
-PYDEPS = pydeps-5.2.0-el7-12
+PYDEPS = pydeps-5.3.0-el7-1
 JSBUILDER = JSBuilder2
 PHANTOMJS = 1.9.7
 

--- a/rpm/makefile
+++ b/rpm/makefile
@@ -65,7 +65,7 @@ $(PKGROOT)/$(RPM):
 		-d 'mariadb-server = 1:5.5.56' \
 		-d 'memcached = 1.4.15' \
 		-d 'MySQL-python = 1.2.5' \
-		-d 'nagios-common = 4.3.2' \
+		-d 'nagios-common = 4.3.4' \
 		-d 'nagios-plugins = 2.2.1' \
 		-d 'nagios-plugins-perl = 2.2.1' \
 		-d 'nagios-plugins-dig  = 2.2.1' \


### PR DESCRIPTION
* Upgrade to latest version (5.3.0) of pydeps:
  * includes PyJWT
  * upgrade python-dateutil
* Upgrade to latest version of nagios-common. (Previous version no longer available in channels.)

**Note:**
This PR is being marked as `Build finished. No test results found.` not because of its content but because of an outdated Jenkins plugin.  The tests actually _do_ pass, but github is not notified of that success. Please consider accepting this PR after manually checking the results.