### PR TITLE
Use pydeps version 5.4.0

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ ITERATION ?= 1
 PLATFORM = x86_64
 RPMVERSION := $(subst -,_,$(VERSION))
 RPM =  $(NAME)-$(RPMVERSION)-$(ITERATION).$(PLATFORM).rpm
-PYDEPS = pydeps-5.3.0-el7-1
+PYDEPS = pydeps-5.4.0-el7-1
 JSBUILDER = JSBuilder2
 PHANTOMJS = 1.9.7
 


### PR DESCRIPTION
This version of pydeps upgrades cryptography package to 1.9
See https://github.com/zenoss/zenoss-py-deps/pull/40

**Note:**
This PR is being marked as `Build finished. No test results found.` not because of its content but because of an outdated Jenkins plugin.  The tests actually _do_ pass, but github is not notified of that success. Please consider accepting this PR after manually checking the results.