### PR TITLE
Bump development version

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@
 
 NAME    ?= zenoss-centos-deps
 IMAGENAME = zenoss-centos-base
-VERSION ?= 1.2.14
+VERSION ?= 1.2.15-dev
 TAG = zenoss/$(IMAGENAME):$(VERSION)
 DEV_TAG = zenoss/$(IMAGENAME):$(VERSION).devtools
 ITERATION ?= 1


### PR DESCRIPTION
Bump develop version to 1.2.15-dev

**Note:**
This PR is being marked as `Build finished. No test results found.` not because of its content but because of an outdated Jenkins plugin. The tests actually do pass, but github is not notified of that success. Please consider accepting this PR after manually checking the results.