### PR TITLE
Build libsmi 0.5.0 into the base image.

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -3,11 +3,9 @@ MAINTAINER Zenoss <dev@zenoss.com>
 
 ADD my.cnf /etc/my.cnf
 
-ADD ./rpm/pkgroot/%RPM% /tmp/%RPM%
+ADD ./rpm/pkgroot/%RPM_DEPS% /tmp/%RPM_DEPS%
+ADD ./libsmi/%RPM_LIBSMI% /tmp/%RPM_LIBSMI%
 
 ADD zenoss_env_init.sh  /tmp/zenoss_env_init.sh
 
 RUN chmod +x /tmp/zenoss_env_init.sh && /tmp/zenoss_env_init.sh
-
-
-

--- a/libsmi/Dockerfile.in
+++ b/libsmi/Dockerfile.in
@@ -1,0 +1,11 @@
+FROM zenoss/build-tools:%BUILD_TOOLS_VERSION%
+MAINTAINER Zenoss <dev@zenoss.com>
+
+# Install stuff for libsmi build and FPM.
+RUN yum -y install libtool flex bison tar gzip make gcc rpm-build ruby-devel && \
+    gem install fpm
+
+RUN groupadd -f -g %GID% build
+RUN useradd -d /home/build -m -s /bin/bash -u %UID% -g %GID% build 
+RUN echo "build ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+USER build

--- a/libsmi/IETF-MIB-LICENSE.txt
+++ b/libsmi/IETF-MIB-LICENSE.txt
@@ -1,0 +1,41 @@
+MIBs included in this software taken from IETF Documents are considered 
+Code Components in accordance with the IETF Trust License Policy, as found
+here:
+
+http://trustee.ietf.org/license-info/
+
+They are available under the terms of the Simplified BSD license, a copy of
+which is included below.
+
+*****
+
+Copyright (c) 2013 IETF Trust and the persons identified as authors of 
+the code.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are 
+met:
+
+· Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer. 
+
+· Redistributions in binary form must reproduce the above copyright 
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+
+· Neither the name of Internet Society, IETF or IETF Trust, nor the 
+names of specific contributors, may be used to endorse or promote 
+products derived from this software without specific prior written 
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS 
+IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER 
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/libsmi/makefile
+++ b/libsmi/makefile
@@ -1,0 +1,123 @@
+#
+# Makefile for building the libsmi 0.5.0 RPM dependency
+#
+
+PWD         := $(shell pwd)
+UID         := $(shell id -u)
+GID         := $(shell id -g)
+
+NAME        := libsmi
+VERSION     := 0.5.0
+ARCH        := x86_64
+RELEASE     := 1.el7
+CATEGORY    := System Environment/Libraries
+SUMMARY     := A library to access SMI MIB information
+URL         := http://ww.ibr.cs.tu-bs.de/projects/libsmi/index.html
+LICENSE     := BSD
+PACKAGER    := Zenoss, Inc. <http://zenoss.com>
+DESCRIPTION := Libsmi is a library and set of tools for checking, dumping, and converting MIB definitions.
+
+PKG_NAME    := $(NAME)-$(VERSION)
+BUILD_DIR   := $(PWD)/build
+PKG_DIR     := $(PWD)/pkg
+USR_DIR     := $(PKG_DIR)/usr
+BIN_DIR     := $(USR_DIR)/bin
+LIB_DIR     := $(USR_DIR)/lib64
+DOC_DIR     := $(USR_DIR)/share/doc/$(PKG_NAME)
+ETC_DIR     := $(PKG_DIR)/etc
+
+SOURCE      := $(PKG_NAME).tar.gz
+SOURCE_DIR  := $(BUILD_DIR)/$(PKG_NAME)
+
+RPM         := $(NAME)-$(VERSION)-$(RELEASE).$(ARCH).rpm
+
+BUILD_TOOLS_VERSION = 0.0.11  # Version of zenoss/build-tools image.
+BUILD_IMAGE         = zenoss/build-libsmi
+
+DOCS = $(DOC_DIR)/ANNOUNCE \
+	   $(DOC_DIR)/ChangeLog \
+	   $(DOC_DIR)/COPYING \
+	   $(DOC_DIR)/draft-irtf-nmrg-sming-02.txt \
+	   $(DOC_DIR)/draft-irtf-nmrg-smi-xml-00.txt \
+	   $(DOC_DIR)/draft-irtf-nmrg-smi-xml-01.txt \
+	   $(DOC_DIR)/ibrpib-assignments.txt \
+	   $(DOC_DIR)/IETF-MIB-LICENSE.txt \
+	   $(DOC_DIR)/README \
+	   $(DOC_DIR)/smi.conf-example \
+	   $(DOC_DIR)/THANKS \
+	   $(DOC_DIR)/TODO
+
+INCLUDE_PATHS = usr/bin \
+				usr/lib64 \
+				usr/share/man/man1 \
+				usr/share/mibs \
+				usr/share/pibs \
+				usr/share/yang \
+				usr/share/doc/$(PKG_NAME) \
+				etc
+
+.PHONY: build clean
+
+build: Dockerfile
+	docker build -t $(BUILD_IMAGE) .
+	docker run --rm -v $${PWD}:/mnt -w /mnt $(BUILD_IMAGE) make $(RPM)
+
+clean:
+	rm -f Dockerfile $(RPM)
+	rm -rf $(BUILD_DIR) $(PKG_DIR)
+	-docker rmi -f $(BUILD_IMAGE) 2>/dev/null
+
+Dockerfile: Dockerfile.in
+	@sed \
+		-e "s/%UID%/$(UID)/g" \
+		-e "s/%GID%/$(GID)/g" \
+		-e "s/%BUILD_TOOLS_VERSION%/$(BUILD_TOOLS_VERSION)/g" \
+		$< > $@
+
+$(BUILD_DIR) $(PKG_DIR) $(ETC_DIR) $(DOC_DIR):
+	mkdir -p $@
+
+$(BUILD_DIR)/$(SOURCE): $(BUILD_DIR)
+	cd $< && curl -O http://zenpip.zenoss.eng/packages/$(notdir $@)
+
+$(SOURCE_DIR): $(BUILD_DIR)/$(SOURCE)
+	cd $(BUILD_DIR) && tar xf $(SOURCE)
+
+$(SOURCE_DIR)/Makefile: $(SOURCE_DIR)
+	cd $< && ./configure --disable-static --prefix=/usr --libdir=/usr/lib64
+
+$(SOURCE_DIR)/tools/.libs/smidump: $(SOURCE_DIR)/Makefile
+	make -C $(SOURCE_DIR)
+
+$(BIN_DIR)/smidump: $(SOURCE_DIR)/tools/.libs/smidump
+	make -C $(SOURCE_DIR) install DESTDIR=$(PKG_DIR)
+
+$(ETC_DIR)/smi.conf: $(ETC_DIR)
+	cp $(notdir $@) $<
+
+$(DOCS): $(DOC_DIR)
+	cp -fu `find ./ -path ./pkg -prune -o -name $(notdir $@) -print` $(DOC_DIR)
+
+$(RPM): $(BIN_DIR)/smidump $(ETC_DIR)/smi.conf $(DOCS)
+	fpm \
+		--verbose \
+		-t rpm \
+		-s dir \
+		-C $(PKG_DIR) \
+		-n $(NAME) \
+		-v $(VERSION) \
+		--iteration $(RELEASE) \
+		-m '$(PACKAGER)' \
+		-p ./ \
+		-x \*pkgconfig\* \
+		-x \*libsmi.la \
+		--category '$(CATEGORY)' \
+		--description '$(DESCRIPTION)' \
+		--license '$(LICENSE)' \
+		--vendor '$(VENDOR)' \
+		--url '$(URL)' \
+		--provides $(NAME) \
+		--rpm-summary '$(SUMMARY)' \
+		--rpm-user root \
+		--rpm-group root \
+		$(INCLUDE_PATHS)

--- a/libsmi/smi.conf
+++ b/libsmi/smi.conf
@@ -1,0 +1,40 @@
+#
+# smi.conf - Global/User SMI configuration file.
+#
+# See smi_config(3) for detailed information on configuration files.
+#
+
+# Extend (note the semicolon) the libsmi default module search path.
+#path :/usr/local/share/mibs/sun
+#path :/usr/local/share/mibs/cisco
+
+# Add a private directory.
+#path :/home/strauss/lib/mibs
+
+# EXPERIMENTAL: Add a caching method (works only on UNIX systems). 
+# NOTE: the cache directory must exist and permissions must be
+# handled appropriately. A simple but insecure way is to apply
+# a tmp flag to the directory (chmod 1777 /usr/local/share/mibs/cache).
+#cache /usr/local/share/mibs/cache /usr/local/bin/smicache -d /usr/local/share/mibs/cache -p http://www.ibr.cs.tu-bs.de/projects/libsmi/smicache/
+
+# Don't show any errors by default.
+level 0
+
+# Preload some basic SMIv2 modules.
+load SNMPv2-SMI
+load SNMPv2-TC
+load SNMPv2-CONF
+
+# Make smilint shout loud to report all errors and warnings.
+smilint: level 9
+
+# But please don't claim about any names longer than 32 chars.
+# (note: this is the prefix of errors `namelength-32-module,
+#  -type, -object, -enumeration, and -bit)
+smilint: hide namelength-32
+
+# Preloading some more modules for special applications.
+tcpdump: load DISMAN-SCRIPT-MIB
+tcpdump: load IF-MIB
+smiquery: load IF-MIB
+

--- a/rpm/makefile
+++ b/rpm/makefile
@@ -61,7 +61,7 @@ $(PKGROOT)/$(RPM):
 		-d 'bzip2' \
 		-d 'hiredis = 0.12.1' \
 		-d 'krb5-workstation = 1.15.1' \
-		-d 'libsmi = 0.4.8' \
+		-d 'libsmi = 0.5.0' \
 		-d 'mariadb-server = 1:5.5.56' \
 		-d 'memcached = 1.4.15' \
 		-d 'MySQL-python = 1.2.5' \

--- a/zenoss_env_init.sh.in
+++ b/zenoss_env_init.sh.in
@@ -36,7 +36,11 @@ yum install -y  --setopt=tsflags="nodocs" \
 # only instal epel here to prevent accidental installs from epel
 yum install epel-release -y 
 
-yum install -y  /tmp/%RPM% 
+# Install the libsmi package  ** INSTALL BEFORE zenoss-centos-deps pkg **
+yum install -y  /tmp/%RPM_LIBSMI% 
+
+# Install the zenoss-centos-deps package
+yum install -y  /tmp/%RPM_DEPS% 
 
 yum erase epel-release -y
 
@@ -64,7 +68,7 @@ su - zenoss -c 'virtualenv /opt/zenoss && virtualenv --relocatable /opt/zenoss'
 cd /tmp 
 wget -qO- http://zenpip.zenoss.eng/packages/%PYDEPS%.tar.gz | tar xz 
 su - zenoss -c 'source /opt/zenoss/bin/activate && \
-    pip install --use-wheel --no-index --find-links=/tmp/%PYDEPS%/wheelhouse -r /tmp/%PYDEPS%/requirements.txt wheel && \
+    pip install --no-index --find-links=/tmp/%PYDEPS%/wheelhouse -r /tmp/%PYDEPS%/requirements.txt wheel && \
     cd /tmp/%PYDEPS%/ && \
     cat patches/* | patch -d $(python -c "import pip, os.path; print os.path.dirname(pip.__path__[0])") -p0 ' 
 


### PR DESCRIPTION
Libsmi version 0.4.8 has a bug that causes infinite loop and memory exhaustion when parsing a MIB node definition containing overlapping range definitions.  Version 0.5.0 of libsmi fixes that issue.

The CentOS repositories do not provide a version of the libsmi package newer than version 0.4.8.  This change builds an RPM out of the libsmi 0.5.0 source archive, installs it, and makes the zenoss-centos-deps package depend on it.

Fixes ZEN-30018.